### PR TITLE
build: log type errors

### DIFF
--- a/gulp/tasks/js.js
+++ b/gulp/tasks/js.js
@@ -12,7 +12,8 @@ const config = require('../config.js');
 const task = {};
 const srcPath = path.resolve(config.srcPath, config.js.src);
 const destPath = path.resolve(config.destPath, config.js.dest);
-const tsProject = ts.createProject('tsconfig.json');
+const tsOptions = process.argv.includes('--disable-typecheck') ? {} : { isolatedModules: false };
+const tsProject = ts.createProject('tsconfig.json', tsOptions);
 
 task['js:clean'] = () => {
   return del(destPath).then(paths => {
@@ -26,7 +27,7 @@ task['js:build'] = () => {
   const tsResult = gulp.src(srcPath)
     .pipe(gulpif(config.env === 'dev', sourcemaps.init()))
     .pipe(tsProject())
-    .on('error', error => log('error', 'js:build', error.toString()));
+    .on('error', error => {});
   log('info', 'js:build', `Build "${config.js.src}".`);
   return tsResult.js
     .pipe(gulpif(config.env === 'dev', sourcemaps.write()))

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "build": "gulp --prod",
     "dev": "gulp watch",
+    "dev-fastbuild": "gulp watch --disable-typecheck",
     "typecheck": "tsc --watch --noEmit",
     "firefox": "web-ext build -s dist -a releases -i=\"**/*.pdn\"",
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
The Problem was that typechecking is disabled with `isolatedModules: true`.

More Infos here:
https://github.com/ivogabe/gulp-typescript/issues/368

So with `isolatedModules: false` the typecheck logging works as expected. But the build is also slower, as all files have to be recompiled each time. So i added a "fastbuild" option, cause i still like to use `npm run typecheck` for typecheck logging and a fast build in general.

```json
    "dev": "gulp watch",
    "dev-fastbuild": "gulp watch --disable-typecheck",
```

But the default production & dev builds now have typecheck logging built in, so everybody should be happy now :)